### PR TITLE
Add models and migrations for User, Url, and Click entities

### DIFF
--- a/app/models/click.rb
+++ b/app/models/click.rb
@@ -1,0 +1,3 @@
+class Click < ApplicationRecord
+  belongs_to :url
+end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -1,0 +1,3 @@
+class Url < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/db/migrate/20241212205256_create_users.rb
+++ b/db/migrate/20241212205256_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241212205524_create_urls.rb
+++ b/db/migrate/20241212205524_create_urls.rb
@@ -1,0 +1,13 @@
+class CreateUrls < ActiveRecord::Migration[7.2]
+  def change
+    create_table :urls do |t|
+      t.string :original_url
+      t.string :short_url
+      t.string :custom_alias
+      t.datetime :expiration_date
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241212205550_create_clicks.rb
+++ b/db/migrate/20241212205550_create_clicks.rb
@@ -1,0 +1,11 @@
+class CreateClicks < ActiveRecord::Migration[7.2]
+  def change
+    create_table :clicks do |t|
+      t.references :url, null: false, foreign_key: true
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,43 @@
+rails db:migrate# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2024_12_12_205550) do
+  create_table "clicks", force: :cascade do |t|
+    t.integer "url_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["url_id"], name: "index_clicks_on_url_id"
+  end
+
+  create_table "urls", force: :cascade do |t|
+    t.string "original_url"
+    t.string "short_url"
+    t.string "custom_alias"
+    t.datetime "expiration_date"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_urls_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "clicks", "urls"
+  add_foreign_key "urls", "users"
+end

--- a/test/fixtures/clicks.yml
+++ b/test/fixtures/clicks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  url: one
+  ip_address: MyString
+  user_agent: MyString
+
+two:
+  url: two
+  ip_address: MyString
+  user_agent: MyString

--- a/test/fixtures/urls.yml
+++ b/test/fixtures/urls.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  original_url: MyString
+  short_url: MyString
+  custom_alias: MyString
+  expiration_date: 2024-12-12 20:55:24
+  user: one
+
+two:
+  original_url: MyString
+  short_url: MyString
+  custom_alias: MyString
+  expiration_date: 2024-12-12 20:55:24
+  user: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  email: MyString
+  password_digest: MyString
+
+two:
+  email: MyString
+  password_digest: MyString

--- a/test/models/click_test.rb
+++ b/test/models/click_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClickTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UrlTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This pull request introduces a new feature for URL shortening, including models, migrations, and tests. The most important changes include creating models for `User`, `Url`, and `Click`, adding corresponding database migrations, and setting up fixtures and basic tests.